### PR TITLE
Company Delivery User 기능 생성

### DIFF
--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/com_delivery/CompanyDeliveryRepository.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/com_delivery/CompanyDeliveryRepository.java
@@ -14,11 +14,11 @@ public interface CompanyDeliveryRepository extends JpaRepository<CompanyDelivery
 
     Optional<CompanyDelivery> findByIdAndDeletedByIsNull(Long id);
 
-    @Query("select d from com_delivery_tb d where d.originHubId in :hubIds and d.deletedBy = null")
+    @Query("select d from com_delivery_tb d where d.originHubId in :hubIds and d.deletedBy is null")
     List<CompanyDelivery> findAllByHubIds(@Param("hubIds") List<Long> hubIdList);
 
     List<CompanyDelivery> findAllByCompanyDeliveryManagerIdAndDeletedByIsNull(Long companyDeliveryManagerId);
 
-    @Query("select d from com_delivery_tb d where d.destinationCompanyId in :companyIdList and d.deletedBy = null")
+    @Query("select d from com_delivery_tb d where d.destinationCompanyId in :companyIdList and d.deletedBy is null")
     List<CompanyDelivery> findAllByDestinationCompanyIds(@Param("companyIdList") List<Long> companyIdList);
 }

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/com_delivery/CompanyDeliveryService.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/com_delivery/CompanyDeliveryService.java
@@ -37,8 +37,8 @@ public class CompanyDeliveryService {
                 CompanyDeliveryStatus.OUT_FOR_DELIVERY,
                 delivery.getOriginHubId(),
                 delivery.getDestinationCompanyId(),
-                10.0, //예상 거리
-                60.0, // 예상 시간
+                19.8, //예상 거리 ( km )
+                1.2, // 예상 시간 ( hour )
                 delivery.getCompanyDeliveryManagerId()
         );
         companyDeliveryRepository.save(companyDelivery);

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryController.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryController.java
@@ -20,31 +20,32 @@ public class DeliveryController {
 
 
     @GetMapping("/{userId}")
-    public ApiResponse<?> getAllDelivery(@PathVariable(name = "userId") Long userId){
+    public ApiResponse<?> getAllDelivery(@PathVariable(name = "userId") Long userId) {
         List<DeliveryResponseDto> response = deliveryService.getAllDelivery(userId);
         return ApiResponse.success(200, response);
     }
+
     @GetMapping("/{deliveryId}/{userId}")
-    public ApiResponse<?> getDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @PathVariable(name = "userId") Long userId){
+    public ApiResponse<?> getDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @PathVariable(name = "userId") Long userId) {
         DeliveryResponseDto response = deliveryService.getDelivery(deliveryId, userId);
         return ApiResponse.success(200, response);
     }
 
     //주문생성시 자동으로 호출 -> message queue 활용
     @PostMapping("/{userId}")
-    public ApiResponse<?> createDelivery(@RequestBody @Valid DeliveryRequestDto requestDto, @PathVariable(name = "userId") Long userId){
+    public ApiResponse<?> createDelivery(@RequestBody @Valid DeliveryRequestDto requestDto, @PathVariable(name = "userId") Long userId) {
         deliveryService.createDelivery(requestDto, userId);
         return ApiResponse.success(201, "배송 생성 완료");
     }
 
     @PatchMapping("/{deliveryId}/{userId}")
-    public ApiResponse<?> updateDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @RequestBody DeliveryUpdateRequestDto requestDto, @PathVariable(name = "userId") Long userId){
+    public ApiResponse<?> updateDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @RequestBody DeliveryUpdateRequestDto requestDto, @PathVariable(name = "userId") Long userId) {
         deliveryService.updateDelivery(deliveryId, requestDto, userId);
         return ApiResponse.success(200, "배송 생성 완료");
     }
 
     @DeleteMapping("/{deliveryId}/{userId}")
-    public ApiResponse<?> deleteDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @PathVariable(name = "userId") Long userId){
+    public ApiResponse<?> deleteDelivery(@PathVariable(name = "deliveryId") Long deliveryId, @PathVariable(name = "userId") Long userId) {
         deliveryService.deleteDelivery(deliveryId, userId);
         return ApiResponse.success(204, "배송 삭제 완료");
     }

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryRepository.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryRepository.java
@@ -12,17 +12,17 @@ import java.util.Optional;
 @Repository
 public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
 
-    @Query("select d from delivery_tb d where d.originHubId = :hubId or d.destinationHubId = :hubId and d.deletedBy = null order by d.id desc")
+    @Query("select d from delivery_tb d where d.originHubId = :hubId or d.destinationHubId = :hubId and d.deletedBy is null order by d.id desc")
     List<Delivery> findAllByHubId(@Param("hubId") Long hubId);
 
-    @Query("select d from delivery_tb d where (d.originHubId in :hubIds or d.destinationHubId in :hubIds) and d.deletedBy = null")
+    @Query("select d from delivery_tb d where (d.originHubId in :hubIds or d.destinationHubId in :hubIds) and d.deletedBy is null")
     List<Delivery> findAllByHubIds(@Param("hubIds") List<Long> hubIds);
 
     List<Delivery> findAllByHubDeliveryManagerIdAndDeletedByIsNull(Long id);
 
     List<Delivery> findAllByCompanyDeliveryManagerIdAndDeletedByIsNull(Long id);
 
-    @Query("select d from delivery_tb d where d.destinationCompanyId in :companyIds ")
+    @Query("select d from delivery_tb d where d.destinationCompanyId in :companyIds and d.deletedBy is null ")
     List<Delivery> findAllByDestinationCompanyIds(@Param("companyIds") List<Long> companyIds);
 
     Optional<Delivery> findByIdAndDeletedByIsNull(Long aLong);

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryService.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryService.java
@@ -11,6 +11,7 @@ import com.ojo.mullyuojo.delivery.domain.delivery.dto.DeliveryRequestDto;
 import com.ojo.mullyuojo.delivery.domain.delivery.dto.DeliveryResponseDto;
 import com.ojo.mullyuojo.delivery.domain.delivery.dto.DeliveryUpdateRequestDto;
 import com.ojo.mullyuojo.delivery.domain.delivery.status.DeliveryStatus;
+import com.ojo.mullyuojo.delivery.domain.delivery_user.CompanyDeliveryUserService;
 import com.ojo.mullyuojo.delivery.domain.hub_delivery.HubDeliveryService;
 import com.ojo.mullyuojo.delivery.domain.hub_delivery.status.HubDeliveryStatus;
 import jakarta.ws.rs.ForbiddenException;

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryService.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/DeliveryService.java
@@ -34,6 +34,7 @@ public class DeliveryService {
     private final CompanyDeliveryService companyDeliveryService;
     private final DeliveryHubClient deliveryHubClient;
     private final DeliveryCompanyClient deliveryCompanyClient;
+    private final CompanyDeliveryUserService companyDeliveryUserService;
     private final List<DeliveryUserDto> users = new ArrayList<>(
             Arrays.asList(
                     new DeliveryUserDto(1L, "MASTER"),
@@ -132,6 +133,9 @@ public class DeliveryService {
         if (!user.getUserRole().equals("MASTER")) {
             throw new ForbiddenException("생성 권한이 없습니다.");
         }
+
+        Long deliveryUserId = companyDeliveryUserService.findNextUserInHub(requestDto.destinationHubId()); // 배송 시퀀스에 따라 배정되는 배송 담당자
+
         Delivery delivery = new Delivery(requestDto.orderId(),
                 requestDto.deliveryStatus(),
                 requestDto.originHubId(),
@@ -140,7 +144,8 @@ public class DeliveryService {
                 requestDto.companyManagerId(),
                 requestDto.companyManagerSlackId(),
                 requestDto.hubDeliveryManagerId(),
-                requestDto.companyDeliveryManagerId());
+                deliveryUserId
+        );
 
         deliveryRepository.save(delivery);
         hubDeliveryService.createHubDeliveryByDelivery(delivery);

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/dto/DeliveryRequestDto.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/dto/DeliveryRequestDto.java
@@ -18,9 +18,7 @@ public record DeliveryRequestDto(
         @NotNull
         String companyManagerSlackId,
         @NotNull
-        Long hubDeliveryManagerId,
+        Long hubDeliveryManagerId
 
-        @NotNull
-        Long companyDeliveryManagerId
 ) {
 }

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/dto/DeliveryUpdateRequestDto.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery/dto/DeliveryUpdateRequestDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 
 @Builder
 public record DeliveryUpdateRequestDto(
-
         Long originHubId,
         Long destinationHubId,
         Long orderId,

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUser.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUser.java
@@ -1,0 +1,55 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user;
+
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserUpdateRequestDto;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Data
+@Entity(name = "com_delivery_user_tb")
+@NoArgsConstructor
+@Table
+public class CompanyDeliveryUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long hubId;
+
+    @Column(nullable = false)
+    private Long sequence;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    private Boolean onDelivery = false;
+
+    private LocalDateTime deletedAt;
+
+    private Long deletedBy;
+
+    public void softDelete(Long id) {
+        this.deletedBy = id;
+    }
+
+    public void onDelivery(Boolean b) {
+        this.onDelivery = b;
+    }
+
+    public void update(CompanyDeliveryUserUpdateRequestDto requestDto) {
+        this.hubId = requestDto.hubId();
+        this.userId = requestDto.userId();
+    }
+
+    public CompanyDeliveryUser(Long hubId, Long sequence, Long userId) {
+        this.hubId = hubId;
+        this.sequence = sequence;
+        this.userId = userId;
+    }
+
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserController.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserController.java
@@ -1,0 +1,50 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user;
+
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserRequestDto;
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserResponseDto;
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserUpdateRequestDto;
+import com.ojo.mullyuojo.delivery.utils.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/delivery-users")
+@RequiredArgsConstructor
+public class CompanyDeliveryUserController {
+
+    private final CompanyDeliveryUserService companyDeliveryUserService;
+
+    @GetMapping()
+    public ApiResponse<?> getAllUser() {
+        List<CompanyDeliveryUserResponseDto> response = companyDeliveryUserService.getAllUser();
+        return ApiResponse.success(200, response);
+    }
+
+    @GetMapping("/{deliveryUserId}")
+    public ApiResponse<?> getUser(@PathVariable(name = "deliveryUserId") Long deliveryUserId) {
+        CompanyDeliveryUserResponseDto response = companyDeliveryUserService.getUser(deliveryUserId);
+        return ApiResponse.success(200, response);
+    }
+
+    @PostMapping()
+    public ApiResponse<?> create(@RequestBody @Valid CompanyDeliveryUserRequestDto requestDto) {
+        CompanyDeliveryUserResponseDto response = companyDeliveryUserService.create(requestDto);
+        return ApiResponse.success(201, "배송 담당자 지정 완료", response);
+    }
+
+    @PatchMapping("/{deliveryUserId}")
+    public ApiResponse<?> updateUser(@RequestBody CompanyDeliveryUserUpdateRequestDto requestDto, @PathVariable(name = "deliveryUserId") Long deliveryUserId) {
+        CompanyDeliveryUserResponseDto response = companyDeliveryUserService.update(deliveryUserId, requestDto);
+        return ApiResponse.success(200, response);
+    }
+
+    @DeleteMapping("/{deliveryUserId}")
+    public ApiResponse<?> delete(@PathVariable(name = "deliveryUserId") Long deliveryUserId) {
+        companyDeliveryUserService.delete(deliveryUserId);
+        return ApiResponse.success(204, "배송 담당자 삭제 완료");
+    }
+
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserRepository.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserRepository.java
@@ -1,0 +1,33 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CompanyDeliveryUserRepository extends JpaRepository<CompanyDeliveryUser, Long> {
+
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u.sequence from com_delivery_user_tb u where u.hubId = :hubId and u.deletedBy is null order by u.sequence desc limit 1")
+    Long findLastSequenceNumberByHubId(@Param("hubId") Long hubId);
+
+    Optional<CompanyDeliveryUser> findByIdAndDeletedByIsNull(Long id);
+
+    List<CompanyDeliveryUser> findAllByDeletedByIsNull();
+
+    @Query("select u from com_delivery_user_tb u where u.hubId = :hubId and u.onDelivery = true and u.deletedBy is null")
+    Optional<CompanyDeliveryUser> findUserOnDelivery(@Param("hubId") Long hubId);
+
+    @Query("select u from com_delivery_user_tb u where u.hubId = :hubId and u.sequence > :lastSequence and u.deletedBy is null order by u.sequence asc limit 1")
+    CompanyDeliveryUser findNextUserByHubIdAndLastSequence(@Param("hubId") Long hubId, @Param("lastSequence") Long lastSequence);
+
+    @Query("select u from com_delivery_user_tb u where u.hubId = :hubId and u.deletedBy is null order by u.sequence asc limit 1")
+    Optional<CompanyDeliveryUser> findFirstUserInHub(@Param("hubId") Long hubId);
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserService.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/CompanyDeliveryUserService.java
@@ -1,0 +1,99 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user;
+
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserRequestDto;
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserResponseDto;
+import com.ojo.mullyuojo.delivery.domain.delivery_user.dto.CompanyDeliveryUserUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CompanyDeliveryUserService {
+
+    private final CompanyDeliveryUserRepository companyDeliveryUserRepository;
+
+    @Transactional
+    public CompanyDeliveryUserResponseDto getUser(Long deliveryUserId) {
+        CompanyDeliveryUser user = findById(deliveryUserId);
+        return CompanyDeliveryUserResponseDto.from(user);
+    }
+
+    @Transactional
+    public List<CompanyDeliveryUserResponseDto> getAllUser() {
+        List<CompanyDeliveryUser> users = companyDeliveryUserRepository.findAllByDeletedByIsNull();
+        return users.stream().map(CompanyDeliveryUserResponseDto::from).toList();
+    }
+
+    @Transactional
+    public CompanyDeliveryUserResponseDto create(CompanyDeliveryUserRequestDto requestDto) {
+
+        Long num = findLastSequenceNum(requestDto.hubId());
+
+        if (num.equals(10L)) {
+            throw new RuntimeException("허브의 배송 담당자는 10명을 초과할 수 없습니다.");
+        }
+
+        CompanyDeliveryUser user = new CompanyDeliveryUser(
+                requestDto.hubId(),
+                num + 1L,
+                requestDto.userId()
+        );
+
+        companyDeliveryUserRepository.save(user);
+        return CompanyDeliveryUserResponseDto.from(user);
+    }
+
+    @Transactional
+    public CompanyDeliveryUserResponseDto update(Long id, CompanyDeliveryUserUpdateRequestDto requestDto) {
+        CompanyDeliveryUser user = findById(id);
+        user.update(requestDto);
+        return CompanyDeliveryUserResponseDto.from(user);
+    }
+
+    @Transactional
+    public void delete(Long deliveryUserId) {
+        CompanyDeliveryUser user = findById(deliveryUserId);
+        user.softDelete(1L);
+    }
+
+    @Transactional
+    public Long findNextUserInHub(Long hubId) {
+
+        Long lastSequence;
+        CompanyDeliveryUser lastUser = companyDeliveryUserRepository.findUserOnDelivery(hubId).orElse(null);
+        if (lastUser == null) {
+            lastSequence = 0L;
+        } else {
+            lastSequence = lastUser.getSequence();
+            if (lastSequence == 10L) { //무조건 10명이 존재한다는 가정
+                lastSequence = 0L;
+            }
+            lastUser.onDelivery(false);
+        }
+        log.info("마지막 배송 순서 : {}", lastSequence);
+        CompanyDeliveryUser nextUser = companyDeliveryUserRepository.findNextUserByHubIdAndLastSequence(hubId, lastSequence);
+        nextUser.onDelivery(true);
+
+        return nextUser.getUserId();
+    }
+
+
+    private CompanyDeliveryUser findById(Long id) {
+        return companyDeliveryUserRepository.findByIdAndDeletedByIsNull(id).orElseThrow(() -> new RuntimeException("해당 배송 담당자를 찾을 수 없습니다."));
+    }
+
+    private Long findLastSequenceNum(Long hubId) {
+        Long num = companyDeliveryUserRepository.findLastSequenceNumberByHubId(hubId);
+        if (num == null) {
+            return 0L;
+        }
+        return num;
+    }
+
+
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserRequestDto.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserRequestDto.java
@@ -1,0 +1,11 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CompanyDeliveryUserRequestDto(
+        @NotNull
+        Long userId,
+        @NotNull
+        Long hubId
+) {
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserResponseDto.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserResponseDto.java
@@ -1,0 +1,17 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user.dto;
+
+import com.ojo.mullyuojo.delivery.domain.delivery_user.CompanyDeliveryUser;
+
+public record CompanyDeliveryUserResponseDto(
+        Long userId,
+        Long hubId,
+        Long sequence
+) {
+    public static CompanyDeliveryUserResponseDto from(CompanyDeliveryUser user) {
+        return new CompanyDeliveryUserResponseDto(
+                user.getUserId(),
+                user.getHubId(),
+                user.getSequence()
+        );
+    }
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserUpdateRequestDto.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/delivery_user/dto/CompanyDeliveryUserUpdateRequestDto.java
@@ -1,0 +1,7 @@
+package com.ojo.mullyuojo.delivery.domain.delivery_user.dto;
+
+public record CompanyDeliveryUserUpdateRequestDto(
+        Long userId,
+        Long hubId
+) {
+}

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/hub_delivery/HubDeliveryRepository.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/domain/hub_delivery/HubDeliveryRepository.java
@@ -14,12 +14,12 @@ public interface HubDeliveryRepository extends JpaRepository<HubDelivery, Long> 
 
     Optional<HubDelivery> findByIdAndDeletedByIsNull(Long aLong);
 
-    @Query("select d from hub_delivery_tb d where (d.originHubId in :hubIds or d.destinationHubId in :hubIds) and d.deletedBy = null")
+    @Query("select d from hub_delivery_tb d where (d.originHubId in :hubIds or d.destinationHubId in :hubIds) and d.deletedBy is null")
     List<HubDelivery> findAllByHubIds(@Param("hubIds") List<Long> hubIdList);
 
     List<HubDelivery> findAllByHubDeliveryManagerIdAndDeletedByIsNull(Long hubDeliveryManagerId);
 
-    @Query("select d from hub_delivery_tb d where d.destinationHubId in :companyIdList and d.deletedBy = null")
+    @Query("select d from hub_delivery_tb d where d.destinationHubId in :companyIdList and d.deletedBy is null")
     List<HubDelivery> findAllByDestinationCompanyIds(@Param("companyIdList") List<Long> companyIdList);
 
     HubDelivery findByDeliveryIdAndDeletedByIsNull(Long deliveryId);

--- a/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/utils/ApiResponse.java
+++ b/com.ojo.mullyuojo.delivery/src/main/java/com/ojo/mullyuojo/delivery/utils/ApiResponse.java
@@ -15,6 +15,9 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(int status, String message) {
         return new ApiResponse<>(status,message,null);
     }
+    public static <T> ApiResponse<T> success(int status, String message, T data) {
+        return new ApiResponse<>(status,message,data);
+    }
     public static <T> ApiResponse<T> error(int status, String message){
         return new ApiResponse<>(status, message, null);
     }


### PR DESCRIPTION
## 📝 요약(Summary)

업체 배송 담당자 기능을 완성했습니다.

## 💫 변경 사항 (Details)

- 업체 배송 담당자는 각 허브당 10명씩 존재
- 기본적인 CRUD 기능 완료 
- delivery 생성시 destinationHubId를 통해 해당 허브를 담당하는 담당자들이 자신에게 부여된 sequence 순서대로 배송이 지정됩니다.

## 📸스크린샷 (선택)
<img width="1254" height="421" alt="image" src="https://github.com/user-attachments/assets/2aadef2a-5dd4-4d7d-8b80-f85ce30a876f" />

<!--- API 테스트 결과 스크린샷 -->

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [ ] Reviewers에 팀원 등록


## 💬 TODO ( 미완성일 경우 )

<!--- 의논해야할 부분이나 더 추가해야할 부분이 있다면 작성 -->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
